### PR TITLE
Fixed mistranslations (2024-03-16)

### DIFF
--- a/avidemux_ja.ts
+++ b/avidemux_ja.ts
@@ -3736,7 +3736,7 @@ Installation mismatch</source>
     <message>
         <location filename="../../../avidemux_core/ADM_core/src/ADM_prettyPrint.cpp" line="-2"/>
         <source>Less than a minute</source>
-        <translation>分未満</translation>
+        <translation>１分以下</translation>
     </message>
     <message>
         <location filename="../../common/ADM_commonUI/myOwnMenu.h" line="-28"/>
@@ -4781,10 +4781,7 @@ Expect problems.</source>
     <message>
         <location filename="../../../avidemux_plugins/ADM_videoFilters6/artMirror/ADM_vidArtMirror.cpp" line="+41"/>
         <source>Mirror</source>
-        <translation variants="yes">
-            <lengthvariant>鏡像</lengthvariant>
-            <lengthvariant></lengthvariant>
-        </translation>
+        <translation>鏡像</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -4797,10 +4794,7 @@ Expect problems.</source>
     <message>
         <location filename="../../../avidemux_plugins/ADM_videoFilters6/artMirror/qt4/artMirror.ui" line="+14"/>
         <source>Mirror</source>
-        <translation variants="yes">
-            <lengthvariant>鏡像</lengthvariant>
-            <lengthvariant></lengthvariant>
-        </translation>
+        <translation>鏡像</translation>
     </message>
     <message>
         <location line="+87"/>
@@ -6758,7 +6752,7 @@ Do you want to load it  ?
     <message>
         <location line="-103"/>
         <source>Phase:</source>
-        <translation>位相:</translation>
+        <translation>状態:</translation>
     </message>
     <message>
         <location line="+475"/>


### PR DESCRIPTION
Fixed mistranslated parts of Conversion status dialog.
1. source -- Phase:
    translation OLD --  位相:
    translation NEW -- 状態:

2. source -- Less than a minute
    translation OLD -- 分未満
    translation NEW -- １分以下